### PR TITLE
Migrate to Koa v2 middleware signature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "iojs-v1"
-  - "iojs-v2"
-  - "0.12"
-  - "0.11"
+  - "4"
+  - "5"
 script: "make test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## Version 0.0.1
 
 - Initial Release
+
+## Version 1.0.0
+
+- Migrate to Koa v2 middleware signature

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are authoring a middleware you can support unless as follow:
 
 ```javascript
 module.exports = function () {
-  var mymid = function *(next) {
+  var mymid = function(ctx, next) {
 	// Do something
   };
 
@@ -42,7 +42,7 @@ module.exports = function () {
 -  `path` it could be an string, a regexp or an array of any of those. If the request path match, the middleware will not run.
 -  `ext` it could be an string or an array of strings. If the request path ends with one of these extensions the middleware will not run.
 -  `custom` it must be a function that returns `true` / `false`. If the function returns true for the given request, ithe middleware will not run. The function will have access to Koa's context via `this`
--  `useOriginalUrl` it should be `true` or `false`, default is `true`. if false, `path` will match against `this.url` instead of `this.originalUrl`.
+-  `useOriginalUrl` it should be `true` or `false`, default is `true`. if false, `path` will match against `ctx.url` instead of `ctx.originalUrl`.
 
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 var url = require('url');
 
 module.exports = function(options) {

--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ module.exports = function(options) {
   var opts = typeof options === 'function' ? {custom: options} : options;
   opts.useOriginalUrl = (typeof opts.useOriginalUrl === 'undefined') ? true : opts.useOriginalUrl;
 
-  return function *(next) {
-    var requestedUrl = url.parse((opts.useOriginalUrl ? this.originalUrl : this.url) || '', true);
+  return function(ctx, next) {
+    var requestedUrl = url.parse((opts.useOriginalUrl ? ctx.originalUrl : ctx.url) || '', true);
 
     var skip = false;
 
     if (opts.custom) {
-      skip = skip || opts.custom.call(this);
+      skip = skip || opts.custom(ctx);
     }
 
     var paths = !opts.path || Array.isArray(opts.path) ?
@@ -38,13 +38,13 @@ module.exports = function(options) {
                   opts.method : [opts.method];
 
     if (methods) {
-      skip = skip || !!~methods.indexOf(this.method);
+      skip = skip || !!~methods.indexOf(ctx.method);
     }
 
     if (skip) {
-      return yield *next;
+      return next();
     }
 
-    yield *parent.call(this, next);
+    return parent(ctx, next);
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-unless",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Conditionally add a middleware to Koa with some common patterns.",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "koa": "^0.21.0",
+    "koa": "^2.0.0",
     "mocha": "^2.2.5",
     "supertest": "^1.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "keywords": [
     "koa",
-    "middleware"
+    "middleware",
+    "unless"
   ],
   "author": "Jesus Rodriguez <Foxandxss@gmail.com>",
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-var koa     = require('koa');
+var Koa     = require('koa');
 var request = require('supertest');
 
 var unless  = require('../index');
@@ -7,8 +7,8 @@ describe('koa-unless', function() {
   var middleware;
 
   beforeEach(function() {
-    middleware = function *(next) {
-      this.body = {executed: true};
+    middleware = function(ctx, next) {
+      ctx.body = {executed: true};
     };
 
     middleware.unless = unless;
@@ -16,7 +16,7 @@ describe('koa-unless', function() {
 
   describe('with PATH exception', function() {
     it('should not call the middleware when one of the path match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
       app.use(middleware.unless({ path: ['/foo'] }));
       request(app.listen())
@@ -25,7 +25,7 @@ describe('koa-unless', function() {
     });
 
     it('should call the middleware when the path doesnt match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
       app.use(middleware.unless({ path: ['/foo'] }));
       request(app.listen())
@@ -36,7 +36,7 @@ describe('koa-unless', function() {
 
   describe('with PATH (regexp) exception', function() {
     it('should not call the middleware when the regex match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
       app.use(middleware.unless({ path: ['/foo', /ar$/ig] }));
       request(app.listen())
@@ -46,12 +46,12 @@ describe('koa-unless', function() {
   });
 
   describe('with PATH (useOriginalUrl) exception', function() {
-    it('should not call the middleware when one of the path match this.url instead of this.originalUrl', function(done) {
-      var app = koa();
+    it('should not call the middleware when one of the path match ctx.url instead of ctx.originalUrl', function(done) {
+      var app = new Koa();
 
-      app.use(function *(next) {
-        this.url = '/foo';
-        yield *next;
+      app.use(function(ctx, next) {
+        ctx.url = '/foo';
+        return next();
       });
       app.use(middleware.unless({ path: ['/foo'], useOriginalUrl: false }));
       request(app.listen())
@@ -59,12 +59,12 @@ describe('koa-unless', function() {
         .expect(404, done);
     });
 
-    it('should call the middleware when the path doesnt match this.url even if path matches this.originalUrl', function(done) {
-      var app = koa();
+    it('should call the middleware when the path doesnt match ctx.url even if path matches ctx.originalUrl', function(done) {
+      var app = new Koa();
 
-      app.use(function *(next) {
-        this.originalUrl = '/foo';
-        yield *next;
+      app.use(function(ctx, next) {
+        ctx.originalUrl = '/foo';
+        return next();
       });
       app.use(middleware.unless({ path: ['/foo'], useOriginalUrl: false }));
       request(app.listen())
@@ -75,7 +75,7 @@ describe('koa-unless', function() {
 
   describe('with EXT exception', function() {
     it('should not call the middleware when the ext match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
       app.use(middleware.unless({ ext: ['html', 'css'] }));
       request(app.listen())
@@ -84,7 +84,7 @@ describe('koa-unless', function() {
     });
 
     it('should call the middleware when the ext doesnt match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
       app.use(middleware.unless({ ext: ['html', 'css'] }));
       request(app.listen())
@@ -95,7 +95,7 @@ describe('koa-unless', function() {
 
   describe('with METHOD exception', function() {
     it('should not call the middleware when the method match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
       app.use(middleware.unless({ method: ['GET', 'OPTIONS'] }));
       request(app.listen())
@@ -104,7 +104,7 @@ describe('koa-unless', function() {
     });
 
     it('should call the middleware when the method doesnt match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
       app.use(middleware.unless({ method: ['GET', 'OPTIONS'] }));
       request(app.listen())
@@ -115,10 +115,10 @@ describe('koa-unless', function() {
 
   describe('with custom exception', function() {
     it('should not call the middleware when the custom rule match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
-      app.use(middleware.unless(function() {
-        return this.url === '/index';
+      app.use(middleware.unless(function(ctx) {
+        return ctx.url === '/index';
       }));
       request(app.listen())
         .get('/index')
@@ -126,10 +126,10 @@ describe('koa-unless', function() {
     });
 
     it('should call the middleware when the custom rule doesnt match', function(done) {
-      var app = koa();
+      var app = new Koa();
 
-      app.use(middleware.unless(function() {
-        return this.url === '/index';
+      app.use(middleware.unless(function(ctx) {
+        return ctx.url === '/index';
       }));
       request(app.listen())
         .get('/home')


### PR DESCRIPTION
- Change middleware to accommodate to new Koa 2.0.0.
- Update unit tests.
