### PR TITLE
Fix custom function ctx usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "6.1"
   - "6"
-  - "5"
-  - "4"
+  - "7"
 script: "make test"

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(options) {
     var requestedUrl = url.parse((opts.useOriginalUrl ? ctx.originalUrl : ctx.url) || '', true);
 
     // any match means 'skip original middleware'
-    if (matchesCustom(this, opts) || matchesPath(requestedUrl, opts) ||
+    if (matchesCustom(ctx, opts) || matchesPath(requestedUrl, opts) ||
         matchesExtension(requestedUrl, opts) || matchesMethod(ctx.method, opts)) {
       return next();
     }
@@ -37,7 +37,7 @@ module.exports = function(options) {
  */
 function matchesCustom(ctx, opts) {
   if (opts.custom) {
-    return opts.custom.call(ctx);
+    return opts.custom(ctx);
   }
   return false;
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "koa": "^0.21.0",
+    "koa": "^2.0.0",
     "mocha": "^2.2.5",
     "supertest": "^1.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "koa": "^2.0.0",
+    "koa": "^2.0.1",
     "mocha": "^2.2.5",
     "supertest": "^1.0.1"
   }

--- a/test/scenarios/custom-rule.scenarios.js
+++ b/test/scenarios/custom-rule.scenarios.js
@@ -1,9 +1,9 @@
-function denyGuard() {
-  return this.url === '/index' || this.url.length === 7;
+function denyGuard(ctx) {
+  return ctx.url === '/index' || ctx.url.length === 7;
 }
 
-function allowGuard() {
-  return this.url === '/a-url-that-doesnt-exist' || this.url.length < 0;
+function allowGuard(ctx) {
+  return ctx.url === '/a-url-that-doesnt-exist' || ctx.url.length < 0;
 }
 
 module.exports = [

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -1,14 +1,16 @@
 'use strict';
 
 const unless  = require('../index');
-const koa = require('koa');
+const Koa = require('koa');
 const request = require('supertest');
 
 module.exports = runTests;
 
+
 function runTests(testName, scenariosPath) {
-  let middleware = function *() {
-    this.body = { executed: true };
+  let middleware = function(ctx, next) {
+    ctx.body = { executed: true };
+    return next();
   };
 
   middleware.unless = unless;
@@ -20,16 +22,16 @@ function runTests(testName, scenariosPath) {
 
       let dontUseOriginalUrl = scenario.dontUseOriginalUrl;
       let config = scenario.config || { path: scenario.path, useOriginalUrl: !dontUseOriginalUrl };
-
+      let readableConfig = typeof config === 'function' ? config.name : JSON.stringify(config);
       let testMethod = scenario.testMethod || 'get';
 
-      it(`should ${acceptDeny} access to ${scenario.testSample} when configured with: ${config}`, function (done) {
-        let app = koa();
+      it(`should ${acceptDeny} access to ${scenario.testSample} when configured with: ${readableConfig}`, function (done) {
+        let app = new Koa();
 
         if (dontUseOriginalUrl) {
-          app.use(function *(next) {
-            this.url = '/foo';
-            yield *next;
+          app.use(function(ctx, next) {
+            ctx.url = '/foo';
+            return next();
           });
         }
 


### PR DESCRIPTION
This fixes issues discussed on #3 and make unit test work again, while being compatible with Koa `^2.0.0`.